### PR TITLE
Limit length of PR body to GH maximum

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install all packages
         run: pnpm install
       - name: Run eslint
-        run: pnpx eslint ./ --max-warnings 0
+        run: pnpx eslint@8.57.0 ./ --max-warnings 0
 
   build:
     name: Build packages

--- a/packages/action/src/util/get-message.ts
+++ b/packages/action/src/util/get-message.ts
@@ -7,6 +7,9 @@ import { ReleaseStats } from './types';
 const capitalise = (str: string) =>
   `${str.at(0)?.toUpperCase() || ''}${str.slice(1)}`;
 
+// GitHub enforces a max length of 65536 characters for a pull request body
+const maxLength = 65536;
+
 export const makeGithubReleaseMessage = (stats: ReleaseStats) =>
   `
 ${Object.entries(stats.pulls)
@@ -22,7 +25,9 @@ ${pulls.map(({ title }) => `- ${title}`).join('\n')}
 ${Array.from(stats.authors)
   .map((author) => `@${author}`)
   .join(', ')}
-`.trim();
+`
+    .trim()
+    .slice(0, maxLength);
 
 const getReleaseMessage = async (prerelease: boolean) => {
   const latestRelease = await getLatestRelease(prerelease);


### PR DESCRIPTION
CI fails if a generated pull request's body exceeds GH's limit. We should prevent this to avoid causing CI to fail in those cases. See [Slack thread](https://whop-workspace.slack.com/archives/C034QJEQDM5/p1718403943370069).