### PR TITLE
Pin eslint version in CI

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install all packages
         run: pnpm install
       - name: Run eslint
-        run: pnpx eslint ./ --max-warnings 0
+        run: pnpx eslint@8.57.0 ./ --max-warnings 0
 
   build:
     name: Build packages


### PR DESCRIPTION
CI is currently red in this repo if you try to open a PR or commit to main because we implicitly download the latest version of eslint (major version 9) which has since been deprecated and no longer supports the eslint config file format we still use (bc this repo is old).

If we pin the version to the latest major version 8, it finally works again so we can land PRs again.