### PR TITLE
Limit length of PR body to GH maximum (again)

### DIFF
--- a/packages/action/src/util/get-message.ts
+++ b/packages/action/src/util/get-message.ts
@@ -9,9 +9,10 @@ const capitalise = (str: string) =>
 
 // GitHub enforces a max length of 65536 characters for a pull request body
 const maxLength = 65536;
+const lengthBuffer = 1000;
 
-export const makeGithubReleaseMessage = (stats: ReleaseStats) =>
-  `
+export const makeGithubReleaseMessage = (stats: ReleaseStats) => {
+  const message = `
 ${Object.entries(stats.pulls)
   .map(
     ([key, pulls]) => `
@@ -25,9 +26,17 @@ ${pulls.map(({ title }) => `- ${title}`).join('\n')}
 ${Array.from(stats.authors)
   .map((author) => `@${author}`)
   .join(', ')}
-`
-    .trim()
-    .slice(0, maxLength);
+`.trim();
+
+  if (message.length >= maxLength) {
+    return `${message.slice(
+      0,
+      maxLength - lengthBuffer,
+    )}...\nThis message has been truncated to avoid exceeding the GitHub API's body limit.`;
+  }
+
+  return message;
+};
 
 const getReleaseMessage = async (prerelease: boolean) => {
   const latestRelease = await getLatestRelease(prerelease);

--- a/packages/action/src/util/get-message.ts
+++ b/packages/action/src/util/get-message.ts
@@ -28,7 +28,7 @@ ${Array.from(stats.authors)
   .join(', ')}
 `.trim();
 
-  if (message.length >= maxLength) {
+  if (message.length >= maxLength - lengthBuffer) {
     return `${message.slice(
       0,
       maxLength - lengthBuffer,


### PR DESCRIPTION
Attempt num 2 since the first time didn't work: https://github.com/whopio/turbo-module/pull/92

CI in apps-monorepo is failing bc the PR body's we generate exceed GH's limit.