### PR TITLE
feat: add monorepo support with configurable paths and prerelease types

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,3 +37,6 @@ inputs:
   pr-title-prefix:
     description: "Prefix for release PR titles (e.g., '[Embedded SDK]')"
     default: ""
+  pr-labels:
+    description: "JSON array of additional labels to add to release PRs"
+    default: "[]"

--- a/action.yml
+++ b/action.yml
@@ -17,3 +17,17 @@ inputs:
     description: "Indicates if the same workflow published a new release to npm, required for 'sync' action"
   version:
     description: "The current verison of the package. Required for 'release'"
+  working-directory:
+    description: "Subdirectory to operate in (for monorepos). Paths are relative to this directory."
+    default: "."
+  version-files:
+    description: "JSON array of package.json paths to update when creating release PRs. All files will be updated to the same version."
+    default: '["package.json"]'
+  publish-packages:
+    description: "JSON array of package paths to check for publishing. If not set, scans packages/* directory."
+  prerelease-type:
+    description: "Prerelease identifier to use (e.g., 'canary', 'beta')"
+    default: "canary"
+  base-branch:
+    description: "Base branch for PRs and releases"
+    default: "main"

--- a/action.yml
+++ b/action.yml
@@ -34,3 +34,6 @@ inputs:
   max-changelog-commits:
     description: "Maximum commits to scan for changelog generation (0 = unlimited)"
     default: "100"
+  pr-title-prefix:
+    description: "Prefix for release PR titles (e.g., '[Embedded SDK]')"
+    default: ""

--- a/action.yml
+++ b/action.yml
@@ -31,3 +31,6 @@ inputs:
   base-branch:
     description: "Base branch for PRs and releases"
     default: "main"
+  max-changelog-commits:
+    description: "Maximum commits to scan for changelog generation (0 = unlimited)"
+    default: "100"

--- a/packages/action/out/174.index.js
+++ b/packages/action/out/174.index.js
@@ -251,12 +251,10 @@ function _ts_generator(thisArg, body) {
 
 var runAction = function() {
     return _async_to_generator(function() {
-        var fullReleaseTitle, prereleaseTitle, stale, stalePrerelease, _iteratorAbruptCompletion, _didIteratorError, _iteratorError, _iterator, _step, _value, pulls, _iteratorNormalCompletion, _didIteratorError1, _iteratorError1, _iterator1, _step1, pull, err, _ref, prereleasePull, fullPull;
+        var stale, stalePrerelease, _iteratorAbruptCompletion, _didIteratorError, _iteratorError, _iterator, _step, _value, pulls, _iteratorNormalCompletion, _didIteratorError1, _iteratorError1, _iterator1, _step1, pull, err, _ref, prereleasePull, fullPull;
         return _ts_generator(this, function(_state) {
             switch(_state.label){
                 case 0:
-                    fullReleaseTitle = (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getFullReleaseTitle */ .n)();
-                    prereleaseTitle = (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getPrereleaseTitle */ .e)();
                     stale = [];
                     stalePrerelease = [];
                     _iteratorAbruptCompletion = false, _didIteratorError = false;
@@ -293,9 +291,13 @@ var runAction = function() {
                     try {
                         for(_iterator1 = pulls[Symbol.iterator](); !(_iteratorNormalCompletion = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion = true){
                             pull = _step1.value;
-                            if ((0,_util_is_action_user__WEBPACK_IMPORTED_MODULE_4__/* ["default"] */ .Z)(pull.user)) {
-                                if (fullReleaseTitle === pull.title) stale.push(pull);
-                                else if (prereleaseTitle === pull.title) stalePrerelease.push(pull);
+                            // Match by branch pattern instead of title (titles now include versions)
+                            if ((0,_util_is_action_user__WEBPACK_IMPORTED_MODULE_4__/* ["default"] */ .Z)(pull.user) && pull.head.ref.startsWith('turbo-module/release-')) {
+                                if (pull.head.ref.includes("-".concat(_context__WEBPACK_IMPORTED_MODULE_1__/* .prereleaseType */ .kD))) {
+                                    stalePrerelease.push(pull);
+                                } else {
+                                    stale.push(pull);
+                                }
                             }
                         }
                     } catch (err) {
@@ -468,11 +470,10 @@ var pull_labels = [
 ];
 var createPull = function(prerelease) {
     return _async_to_generator(function() {
-        var title, releaseLabel, primaryVersionFile, _ref, content, packageJson, newVersion, _ref1, _ref_data, sha, shortSha, branch, _iteratorNormalCompletion, _didIteratorError, _iteratorError, _iterator, _step, versionFile, filePath, _ref2, fileContent, filePackageJson, err, message, _ref3, pull, _$err, e;
+        var releaseLabel, primaryVersionFile, _ref, content, packageJson, newVersion, title, _ref1, _ref_data, sha, shortSha, branch, _iteratorNormalCompletion, _didIteratorError, _iteratorError, _iterator, _step, versionFile, filePath, _ref2, fileContent, filePackageJson, err, message, _ref3, pull, _$err, e;
         return _ts_generator(this, function(_state) {
             switch(_state.label){
                 case 0:
-                    title = prerelease ? (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getPrereleaseTitle */ .e)() : (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getFullReleaseTitle */ .n)();
                     releaseLabel = prerelease ? "releases: ".concat(_context__WEBPACK_IMPORTED_MODULE_1__/* .prereleaseType */ .kD) : 'releases: patch';
                     // Get the first version file to determine current version
                     primaryVersionFile = (0,_context__WEBPACK_IMPORTED_MODULE_1__/* .withWorkingDir */ .QV)(_context__WEBPACK_IMPORTED_MODULE_1__/* .versionFiles[0] */ .dm[0]);
@@ -494,6 +495,7 @@ var createPull = function(prerelease) {
                         newVersion = prerelease ? semver_functions_inc__WEBPACK_IMPORTED_MODULE_0___default()(packageJson.version, 'prerelease', _context__WEBPACK_IMPORTED_MODULE_1__/* .prereleaseType */ .kD) : semver_functions_inc__WEBPACK_IMPORTED_MODULE_0___default()(packageJson.version, 'patch');
                     }
                     if (!newVersion) throw new Error('Could not increase version');
+                    title = prerelease ? (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getPrereleaseTitle */ .e)(newVersion) : (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getFullReleaseTitle */ .n)(newVersion);
                     return [
                         4,
                         _context__WEBPACK_IMPORTED_MODULE_1__/* .octo.rest.git.getRef */ .NR.rest.git.getRef({
@@ -612,7 +614,8 @@ var createPull = function(prerelease) {
                             title: title,
                             body: message,
                             head: branch,
-                            base: _context__WEBPACK_IMPORTED_MODULE_1__/* .baseBranch */ .a2
+                            base: _context__WEBPACK_IMPORTED_MODULE_1__/* .baseBranch */ .a2,
+                            draft: true
                         })
                     ];
                 case 14:
@@ -690,11 +693,11 @@ var createPull = function(prerelease) {
 /* harmony export */ });
 /* harmony import */ var _context__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(7501);
 
-var getFullReleaseTitle = function() {
-    return '(turbo-module): release next version';
+var getFullReleaseTitle = function(version) {
+    return version ? "Release v".concat(version) : '(turbo-module): release next version';
 };
-var getPrereleaseTitle = function() {
-    return "(turbo-module): release next ".concat(_context__WEBPACK_IMPORTED_MODULE_0__/* .prereleaseType */ .kD, " version");
+var getPrereleaseTitle = function(version) {
+    return version ? "Release v".concat(version) : "(turbo-module): release next ".concat(_context__WEBPACK_IMPORTED_MODULE_0__/* .prereleaseType */ .kD, " version");
 };
 
 

--- a/packages/action/out/174.index.js
+++ b/packages/action/out/174.index.js
@@ -693,11 +693,17 @@ var createPull = function(prerelease) {
 /* harmony export */ });
 /* harmony import */ var _context__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(7501);
 
+var formatTitle = function(releaseType, version) {
+    var prefix = _context__WEBPACK_IMPORTED_MODULE_0__/* .prTitlePrefix */ .hJ ? "".concat(_context__WEBPACK_IMPORTED_MODULE_0__/* .prTitlePrefix */ .hJ, " ") : '';
+    var versionSuffix = version ? " v".concat(version) : '';
+    return "".concat(prefix).concat(releaseType).concat(versionSuffix).trim();
+};
 var getFullReleaseTitle = function(version) {
-    return version ? "Release v".concat(version) : '(turbo-module): release next version';
+    return formatTitle('Stable Release', version);
 };
 var getPrereleaseTitle = function(version) {
-    return version ? "Release v".concat(version) : "(turbo-module): release next ".concat(_context__WEBPACK_IMPORTED_MODULE_0__/* .prereleaseType */ .kD, " version");
+    var releaseType = _context__WEBPACK_IMPORTED_MODULE_0__/* .prereleaseType.charAt */ .kD.charAt(0).toUpperCase() + _context__WEBPACK_IMPORTED_MODULE_0__/* .prereleaseType.slice */ .kD.slice(1);
+    return formatTitle("".concat(releaseType, " Release"), version);
 };
 
 

--- a/packages/action/out/174.index.js
+++ b/packages/action/out/174.index.js
@@ -15,8 +15,8 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var semver_functions_inc__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(semver_functions_inc__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _context__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(7501);
 /* harmony import */ var _util_get_message__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(767);
-/* harmony import */ var _util_is_action_user__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(1514);
-/* harmony import */ var _shared__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(8089);
+/* harmony import */ var _util_is_action_user__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(1514);
+/* harmony import */ var _shared__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(8089);
 function _array_like_to_array(arr, len) {
     if (len == null || len > arr.length) len = arr.length;
     for(var i = 0, arr2 = new Array(len); i < len; i++)arr2[i] = arr[i];
@@ -251,12 +251,14 @@ function _ts_generator(thisArg, body) {
 
 var runAction = function() {
     return _async_to_generator(function() {
-        var stale, staleCanary, _iteratorAbruptCompletion, _didIteratorError, _iteratorError, _iterator, _step, _value, pulls, _iteratorNormalCompletion, _didIteratorError1, _iteratorError1, _iterator1, _step1, pull, err, _ref, canaryPull, fullPull;
+        var fullReleaseTitle, prereleaseTitle, stale, stalePrerelease, _iteratorAbruptCompletion, _didIteratorError, _iteratorError, _iterator, _step, _value, pulls, _iteratorNormalCompletion, _didIteratorError1, _iteratorError1, _iterator1, _step1, pull, err, _ref, prereleasePull, fullPull;
         return _ts_generator(this, function(_state) {
             switch(_state.label){
                 case 0:
+                    fullReleaseTitle = (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getFullReleaseTitle */ .n)();
+                    prereleaseTitle = (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getPrereleaseTitle */ .e)();
                     stale = [];
-                    staleCanary = [];
+                    stalePrerelease = [];
                     _iteratorAbruptCompletion = false, _didIteratorError = false;
                     _state.label = 1;
                 case 1:
@@ -291,9 +293,9 @@ var runAction = function() {
                     try {
                         for(_iterator1 = pulls[Symbol.iterator](); !(_iteratorNormalCompletion = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion = true){
                             pull = _step1.value;
-                            if ((0,_util_is_action_user__WEBPACK_IMPORTED_MODULE_3__/* ["default"] */ .Z)(pull.user)) {
-                                if (_shared__WEBPACK_IMPORTED_MODULE_4__/* .fullReleaseTitle */ .o === pull.title) stale.push(pull);
-                                else if (_shared__WEBPACK_IMPORTED_MODULE_4__/* .canaryReleaseTitle */ .G === pull.title) staleCanary.push(pull);
+                            if ((0,_util_is_action_user__WEBPACK_IMPORTED_MODULE_4__/* ["default"] */ .Z)(pull.user)) {
+                                if (fullReleaseTitle === pull.title) stale.push(pull);
+                                else if (prereleaseTitle === pull.title) stalePrerelease.push(pull);
                             }
                         }
                     } catch (err) {
@@ -368,7 +370,7 @@ var runAction = function() {
                     // close stale PRs and delete the branches
                     return [
                         4,
-                        Promise.all(_to_consumable_array(stale).concat(_to_consumable_array(staleCanary)).map(function(stalePull) {
+                        Promise.all(_to_consumable_array(stale).concat(_to_consumable_array(stalePrerelease)).map(function(stalePull) {
                             return _async_to_generator(function() {
                                 return _ts_generator(this, function(_state) {
                                     switch(_state.label){
@@ -415,13 +417,13 @@ var runAction = function() {
                     _ref = _sliced_to_array.apply(void 0, [
                         _state.sent(),
                         2
-                    ]), canaryPull = _ref[0], fullPull = _ref[1];
+                    ]), prereleasePull = _ref[0], fullPull = _ref[1];
                     // add comments to closed PRs that link to the newly created PRs
                     return [
                         4,
                         Promise.all([
-                            Promise.all(staleCanary.map(function(pull) {
-                                return addCommentToClosed(pull.number, canaryPull.number);
+                            Promise.all(stalePrerelease.map(function(pull) {
+                                return addCommentToClosed(pull.number, prereleasePull.number);
                             })),
                             Promise.all(stale.map(function(pull) {
                                 return addCommentToClosed(pull.number, fullPull.number);
@@ -466,18 +468,20 @@ var pull_labels = [
 ];
 var createPull = function(prerelease) {
     return _async_to_generator(function() {
-        var title, releaseLabel, _ref, content, packageJson, newVersion, _ref1, _ref_data, sha, shortSha, branch, message, _ref2, pull, err, e;
+        var title, releaseLabel, primaryVersionFile, _ref, content, packageJson, newVersion, _ref1, _ref_data, sha, shortSha, branch, _iteratorNormalCompletion, _didIteratorError, _iteratorError, _iterator, _step, versionFile, filePath, _ref2, fileContent, filePackageJson, err, message, _ref3, pull, _$err, e;
         return _ts_generator(this, function(_state) {
             switch(_state.label){
                 case 0:
-                    title = prerelease ? _shared__WEBPACK_IMPORTED_MODULE_4__/* .canaryReleaseTitle */ .G : _shared__WEBPACK_IMPORTED_MODULE_4__/* .fullReleaseTitle */ .o;
-                    releaseLabel = prerelease ? 'releases: canary' : 'releases: patch';
+                    title = prerelease ? (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getPrereleaseTitle */ .e)() : (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getFullReleaseTitle */ .n)();
+                    releaseLabel = prerelease ? "releases: ".concat(_context__WEBPACK_IMPORTED_MODULE_1__/* .prereleaseType */ .kD) : 'releases: patch';
+                    // Get the first version file to determine current version
+                    primaryVersionFile = (0,_context__WEBPACK_IMPORTED_MODULE_1__/* .withWorkingDir */ .QV)(_context__WEBPACK_IMPORTED_MODULE_1__/* .versionFiles[0] */ .dm[0]);
                     return [
                         4,
                         _context__WEBPACK_IMPORTED_MODULE_1__/* .octo.rest.repos.getContent */ .NR.rest.repos.getContent({
                             repo: _context__WEBPACK_IMPORTED_MODULE_1__/* .repo */ .O9,
                             owner: _context__WEBPACK_IMPORTED_MODULE_1__/* .owner */ .cR,
-                            path: 'package.json'
+                            path: primaryVersionFile
                         })
                     ];
                 case 1:
@@ -485,24 +489,23 @@ var createPull = function(prerelease) {
                     if (!('content' in content)) throw new Error('Could not get package.json contents');
                     packageJson = JSON.parse(Buffer.from(content.content, 'base64').toString());
                     if (!packageJson.version || packageJson.version.startsWith('0.0.0')) {
-                        newVersion = prerelease ? '0.0.1-canary.0' : '0.0.1';
+                        newVersion = prerelease ? "0.0.1-".concat(_context__WEBPACK_IMPORTED_MODULE_1__/* .prereleaseType */ .kD, ".0") : '0.0.1';
                     } else {
-                        newVersion = prerelease ? semver_functions_inc__WEBPACK_IMPORTED_MODULE_0___default()(packageJson.version, 'prerelease', 'canary') : semver_functions_inc__WEBPACK_IMPORTED_MODULE_0___default()(packageJson.version, 'patch');
+                        newVersion = prerelease ? semver_functions_inc__WEBPACK_IMPORTED_MODULE_0___default()(packageJson.version, 'prerelease', _context__WEBPACK_IMPORTED_MODULE_1__/* .prereleaseType */ .kD) : semver_functions_inc__WEBPACK_IMPORTED_MODULE_0___default()(packageJson.version, 'patch');
                     }
                     if (!newVersion) throw new Error('Could not increase version');
-                    packageJson.version = newVersion;
                     return [
                         4,
                         _context__WEBPACK_IMPORTED_MODULE_1__/* .octo.rest.git.getRef */ .NR.rest.git.getRef({
                             owner: _context__WEBPACK_IMPORTED_MODULE_1__/* .owner */ .cR,
                             repo: _context__WEBPACK_IMPORTED_MODULE_1__/* .repo */ .O9,
-                            ref: "heads/main"
+                            ref: "heads/".concat(_context__WEBPACK_IMPORTED_MODULE_1__/* .baseBranch */ .a2)
                         })
                     ];
                 case 2:
                     _ref1 = _state.sent(), _ref_data = _ref1.data, sha = _ref_data.object.sha;
                     shortSha = sha.slice(0, 6) + sha.slice(-6);
-                    branch = prerelease ? "turbo-module/release-".concat(shortSha, "-canary") : "turbo-module/release-".concat(shortSha);
+                    branch = prerelease ? "turbo-module/release-".concat(shortSha, "-").concat(_context__WEBPACK_IMPORTED_MODULE_1__/* .prereleaseType */ .kD) : "turbo-module/release-".concat(shortSha);
                     return [
                         4,
                         _context__WEBPACK_IMPORTED_MODULE_1__/* .octo.rest.git.createRef */ .NR.rest.git.createRef({
@@ -514,25 +517,92 @@ var createPull = function(prerelease) {
                     ];
                 case 3:
                     _state.sent();
+                    _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
+                    _state.label = 4;
+                case 4:
+                    _state.trys.push([
+                        4,
+                        10,
+                        11,
+                        12
+                    ]);
+                    _iterator = _context__WEBPACK_IMPORTED_MODULE_1__/* .versionFiles */ .dm[Symbol.iterator]();
+                    _state.label = 5;
+                case 5:
+                    if (!!(_iteratorNormalCompletion = (_step = _iterator.next()).done)) return [
+                        3,
+                        9
+                    ];
+                    versionFile = _step.value;
+                    filePath = (0,_context__WEBPACK_IMPORTED_MODULE_1__/* .withWorkingDir */ .QV)(versionFile);
+                    console.log("Updating version in ".concat(filePath, " to ").concat(newVersion));
+                    return [
+                        4,
+                        _context__WEBPACK_IMPORTED_MODULE_1__/* .octo.rest.repos.getContent */ .NR.rest.repos.getContent({
+                            repo: _context__WEBPACK_IMPORTED_MODULE_1__/* .repo */ .O9,
+                            owner: _context__WEBPACK_IMPORTED_MODULE_1__/* .owner */ .cR,
+                            path: filePath,
+                            ref: branch
+                        })
+                    ];
+                case 6:
+                    _ref2 = _state.sent(), fileContent = _ref2.data;
+                    if (!('content' in fileContent)) throw new Error("Could not get ".concat(filePath, " contents"));
+                    filePackageJson = JSON.parse(Buffer.from(fileContent.content, 'base64').toString());
+                    filePackageJson.version = newVersion;
                     return [
                         4,
                         _context__WEBPACK_IMPORTED_MODULE_1__/* .octo.rest.repos.createOrUpdateFileContents */ .NR.rest.repos.createOrUpdateFileContents({
                             repo: _context__WEBPACK_IMPORTED_MODULE_1__/* .repo */ .O9,
                             owner: _context__WEBPACK_IMPORTED_MODULE_1__/* .owner */ .cR,
-                            path: 'package.json',
-                            message: "release patch ".concat(packageJson.version),
-                            content: Buffer.from(JSON.stringify(packageJson, null, 2) + '\n').toString('base64'),
-                            sha: content.sha,
+                            path: filePath,
+                            message: "release: ".concat(newVersion),
+                            content: Buffer.from(JSON.stringify(filePackageJson, null, 2) + '\n').toString('base64'),
+                            sha: fileContent.sha,
                             branch: branch
                         })
                     ];
-                case 4:
+                case 7:
                     _state.sent();
+                    _state.label = 8;
+                case 8:
+                    _iteratorNormalCompletion = true;
+                    return [
+                        3,
+                        5
+                    ];
+                case 9:
+                    return [
+                        3,
+                        12
+                    ];
+                case 10:
+                    err = _state.sent();
+                    _didIteratorError = true;
+                    _iteratorError = err;
+                    return [
+                        3,
+                        12
+                    ];
+                case 11:
+                    try {
+                        if (!_iteratorNormalCompletion && _iterator.return != null) {
+                            _iterator.return();
+                        }
+                    } finally{
+                        if (_didIteratorError) {
+                            throw _iteratorError;
+                        }
+                    }
+                    return [
+                        7
+                    ];
+                case 12:
                     return [
                         4,
                         (0,_util_get_message__WEBPACK_IMPORTED_MODULE_2__/* ["default"] */ .Z)(prerelease)
                     ];
-                case 5:
+                case 13:
                     message = _state.sent().message;
                     return [
                         4,
@@ -542,25 +612,25 @@ var createPull = function(prerelease) {
                             title: title,
                             body: message,
                             head: branch,
-                            base: 'main'
+                            base: _context__WEBPACK_IMPORTED_MODULE_1__/* .baseBranch */ .a2
                         })
                     ];
-                case 6:
-                    _ref2 = _state.sent(), pull = _ref2.data;
-                    err = 0;
-                    _state.label = 7;
-                case 7:
-                    if (!(err < 5)) return [
+                case 14:
+                    _ref3 = _state.sent(), pull = _ref3.data;
+                    _$err = 0;
+                    _state.label = 15;
+                case 15:
+                    if (!(_$err < 5)) return [
                         3,
-                        13
+                        21
                     ];
-                    _state.label = 8;
-                case 8:
+                    _state.label = 16;
+                case 16:
                     _state.trys.push([
-                        8,
-                        10,
+                        16,
+                        18,
                         ,
-                        12
+                        20
                     ]);
                     return [
                         4,
@@ -573,34 +643,34 @@ var createPull = function(prerelease) {
                             ])
                         })
                     ];
-                case 9:
+                case 17:
                     _state.sent();
                     return [
                         2,
                         pull
                     ];
-                case 10:
+                case 18:
                     e = _state.sent();
                     console.error(e);
-                    err++;
+                    _$err++;
                     return [
                         4,
                         new Promise(function(resolve) {
                             return setTimeout(resolve, 300);
                         })
                     ];
-                case 11:
+                case 19:
                     _state.sent();
                     return [
                         3,
-                        12
+                        20
                     ];
-                case 12:
+                case 20:
                     return [
                         3,
-                        7
+                        15
                     ];
-                case 13:
+                case 21:
                     throw new Error('Could not add labels to PR');
             }
         });
@@ -615,11 +685,17 @@ var createPull = function(prerelease) {
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   "G": () => (/* binding */ canaryReleaseTitle),
-/* harmony export */   "o": () => (/* binding */ fullReleaseTitle)
+/* harmony export */   "e": () => (/* binding */ getPrereleaseTitle),
+/* harmony export */   "n": () => (/* binding */ getFullReleaseTitle)
 /* harmony export */ });
-var fullReleaseTitle = '(turbo-module): release next version';
-var canaryReleaseTitle = '(turbo-module): release next canary version';
+/* harmony import */ var _context__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(7501);
+
+var getFullReleaseTitle = function() {
+    return '(turbo-module): release next version';
+};
+var getPrereleaseTitle = function() {
+    return "(turbo-module): release next ".concat(_context__WEBPACK_IMPORTED_MODULE_0__/* .prereleaseType */ .kD, " version");
+};
 
 
 /***/ }),
@@ -631,11 +707,11 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-/* harmony import */ var _util_is_action_user__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(1514);
+/* harmony import */ var _util_is_action_user__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(1514);
 /* harmony import */ var _context__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(7501);
 /* harmony import */ var _util_get_message__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(767);
-/* harmony import */ var _shared__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(8089);
-/* harmony import */ var _create__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(3607);
+/* harmony import */ var _shared__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(8089);
+/* harmony import */ var _create__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(3607);
 function _async_iterator(iterable) {
     var method, async, sync, retry = 2;
     for("undefined" != typeof Symbol && (async = Symbol.asyncIterator, sync = Symbol.iterator); retry--;){
@@ -849,10 +925,12 @@ var syncPull = function(pull, prerelease) {
 };
 var runAction = function() {
     return _async_to_generator(function() {
-        var full, canary, _iteratorAbruptCompletion, _didIteratorError, _iteratorError, _iterator, _step, _value, pulls, _iteratorNormalCompletion, _didIteratorError1, _iteratorError1, _iterator1, _step1, pull, err;
+        var fullReleaseTitle, prereleaseTitle, full, prerelease, _iteratorAbruptCompletion, _didIteratorError, _iteratorError, _iterator, _step, _value, pulls, _iteratorNormalCompletion, _didIteratorError1, _iteratorError1, _iterator1, _step1, pull, err;
         return _ts_generator(this, function(_state) {
             switch(_state.label){
                 case 0:
+                    fullReleaseTitle = (0,_shared__WEBPACK_IMPORTED_MODULE_2__/* .getFullReleaseTitle */ .n)();
+                    prereleaseTitle = (0,_shared__WEBPACK_IMPORTED_MODULE_2__/* .getPrereleaseTitle */ .e)();
                     _iteratorAbruptCompletion = false, _didIteratorError = false;
                     _state.label = 1;
                 case 1:
@@ -887,21 +965,21 @@ var runAction = function() {
                     try {
                         for(_iterator1 = pulls[Symbol.iterator](); !(_iteratorNormalCompletion = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion = true){
                             pull = _step1.value;
-                            if ((0,_util_is_action_user__WEBPACK_IMPORTED_MODULE_3__/* ["default"] */ .Z)(pull.user)) {
+                            if ((0,_util_is_action_user__WEBPACK_IMPORTED_MODULE_4__/* ["default"] */ .Z)(pull.user)) {
                                 switch(pull.title){
-                                    case _shared__WEBPACK_IMPORTED_MODULE_4__/* .fullReleaseTitle */ .o:
+                                    case fullReleaseTitle:
                                         {
                                             if (!full) full = syncPull(pull, false);
                                             break;
                                         }
-                                    case _shared__WEBPACK_IMPORTED_MODULE_4__/* .canaryReleaseTitle */ .G:
+                                    case prereleaseTitle:
                                         {
-                                            if (!canary) canary = syncPull(pull, true);
+                                            if (!prerelease) prerelease = syncPull(pull, true);
                                             break;
                                         }
                                 }
                             }
-                            if (full && canary) break;
+                            if (full && prerelease) break;
                         }
                     } catch (err) {
                         _didIteratorError1 = true;
@@ -917,7 +995,7 @@ var runAction = function() {
                             }
                         }
                     }
-                    if (full && canary) return [
+                    if (full && prerelease) return [
                         3,
                         5
                     ];
@@ -976,13 +1054,13 @@ var runAction = function() {
                         7
                     ];
                 case 12:
-                    if (!full) full = (0,_create__WEBPACK_IMPORTED_MODULE_2__.createPull)(false);
-                    if (!canary) canary = (0,_create__WEBPACK_IMPORTED_MODULE_2__.createPull)(true);
+                    if (!full) full = (0,_create__WEBPACK_IMPORTED_MODULE_3__.createPull)(false);
+                    if (!prerelease) prerelease = (0,_create__WEBPACK_IMPORTED_MODULE_3__.createPull)(true);
                     return [
                         4,
                         Promise.all([
                             full,
-                            canary
+                            prerelease
                         ])
                     ];
                 case 13:

--- a/packages/action/out/174.index.js
+++ b/packages/action/out/174.index.js
@@ -467,7 +467,7 @@ var addCommentToClosed = function(number, replacement) {
 var pull_labels = [
     'auto-release-pr',
     'keep up-to-date'
-];
+].concat(_to_consumable_array(_context__WEBPACK_IMPORTED_MODULE_1__/* .prLabels */ .Zh));
 var createPull = function(prerelease) {
     return _async_to_generator(function() {
         var releaseLabel, primaryVersionFile, _ref, content, packageJson, newVersion, title, _ref1, _ref_data, sha, shortSha, branch, _iteratorNormalCompletion, _didIteratorError, _iteratorError, _iterator, _step, versionFile, filePath, _ref2, fileContent, filePackageJson, err, message, _ref3, pull, _$err, e;

--- a/packages/action/out/212.index.js
+++ b/packages/action/out/212.index.js
@@ -1016,6 +1016,7 @@ var checkPackages = function(rootVersion) {
 /* harmony export */   "a2": () => (/* binding */ baseBranch),
 /* harmony export */   "cR": () => (/* binding */ owner),
 /* harmony export */   "dm": () => (/* binding */ versionFiles),
+/* harmony export */   "hJ": () => (/* binding */ prTitlePrefix),
 /* harmony export */   "hl": () => (/* binding */ commit_hash),
 /* harmony export */   "kD": () => (/* binding */ prereleaseType),
 /* harmony export */   "pE": () => (/* binding */ maxChangelogCommits),
@@ -1042,6 +1043,7 @@ var publishPackages = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('p
 var prereleaseType = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('prerelease-type') || 'canary';
 var baseBranch = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('base-branch') || 'main';
 var maxChangelogCommits = parseInt((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('max-changelog-commits') || '100', 10);
+var prTitlePrefix = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('pr-title-prefix') || '';
 // Helper to join working directory with a path
 var withWorkingDir = function(path) {
     if (workingDirectory === '.') return path;

--- a/packages/action/out/212.index.js
+++ b/packages/action/out/212.index.js
@@ -1013,6 +1013,7 @@ var checkPackages = function(rootVersion) {
 /* harmony export */   "RL": () => (/* binding */ target_comment),
 /* harmony export */   "RP": () => (/* binding */ publishPackages),
 /* harmony export */   "Tf": () => (/* binding */ workingDirectory),
+/* harmony export */   "Zh": () => (/* binding */ prLabels),
 /* harmony export */   "a2": () => (/* binding */ baseBranch),
 /* harmony export */   "cR": () => (/* binding */ owner),
 /* harmony export */   "dm": () => (/* binding */ versionFiles),
@@ -1044,6 +1045,7 @@ var prereleaseType = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('pr
 var baseBranch = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('base-branch') || 'main';
 var maxChangelogCommits = parseInt((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('max-changelog-commits') || '100', 10);
 var prTitlePrefix = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('pr-title-prefix') || '';
+var prLabels = JSON.parse((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('pr-labels') || '[]');
 // Helper to join working directory with a path
 var withWorkingDir = function(path) {
     if (workingDirectory === '.') return path;

--- a/packages/action/out/212.index.js
+++ b/packages/action/out/212.index.js
@@ -1017,6 +1017,7 @@ var checkPackages = function(rootVersion) {
 /* harmony export */   "dm": () => (/* binding */ versionFiles),
 /* harmony export */   "hl": () => (/* binding */ commit_hash),
 /* harmony export */   "kD": () => (/* binding */ prereleaseType),
+/* harmony export */   "pE": () => (/* binding */ maxChangelogCommits),
 /* harmony export */   "sS": () => (/* binding */ initial_commit)
 /* harmony export */ });
 /* unused harmony exports target_pull, workingDirectory */
@@ -1039,6 +1040,7 @@ var versionFiles = JSON.parse((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getI
 var publishPackages = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('publish-packages') ? JSON.parse((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('publish-packages')) : undefined;
 var prereleaseType = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('prerelease-type') || 'canary';
 var baseBranch = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('base-branch') || 'main';
+var maxChangelogCommits = parseInt((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('max-changelog-commits') || '100', 10);
 // Helper to join working directory with a path
 var withWorkingDir = function(path) {
     if (workingDirectory === '.') return path;

--- a/packages/action/out/212.index.js
+++ b/packages/action/out/212.index.js
@@ -1012,6 +1012,7 @@ var checkPackages = function(rootVersion) {
 /* harmony export */   "QV": () => (/* binding */ withWorkingDir),
 /* harmony export */   "RL": () => (/* binding */ target_comment),
 /* harmony export */   "RP": () => (/* binding */ publishPackages),
+/* harmony export */   "Tf": () => (/* binding */ workingDirectory),
 /* harmony export */   "a2": () => (/* binding */ baseBranch),
 /* harmony export */   "cR": () => (/* binding */ owner),
 /* harmony export */   "dm": () => (/* binding */ versionFiles),
@@ -1020,7 +1021,7 @@ var checkPackages = function(rootVersion) {
 /* harmony export */   "pE": () => (/* binding */ maxChangelogCommits),
 /* harmony export */   "sS": () => (/* binding */ initial_commit)
 /* harmony export */ });
-/* unused harmony exports target_pull, workingDirectory */
+/* unused harmony export target_pull */
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(1416);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _actions_github__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(7036);

--- a/packages/action/out/587.index.js
+++ b/packages/action/out/587.index.js
@@ -18,6 +18,7 @@ exports.modules = {
 /* harmony export */   "dm": () => (/* binding */ versionFiles),
 /* harmony export */   "hl": () => (/* binding */ commit_hash),
 /* harmony export */   "kD": () => (/* binding */ prereleaseType),
+/* harmony export */   "pE": () => (/* binding */ maxChangelogCommits),
 /* harmony export */   "sS": () => (/* binding */ initial_commit)
 /* harmony export */ });
 /* unused harmony exports target_pull, workingDirectory */
@@ -40,6 +41,7 @@ var versionFiles = JSON.parse((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getI
 var publishPackages = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('publish-packages') ? JSON.parse((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('publish-packages')) : undefined;
 var prereleaseType = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('prerelease-type') || 'canary';
 var baseBranch = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('base-branch') || 'main';
+var maxChangelogCommits = parseInt((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('max-changelog-commits') || '100', 10);
 // Helper to join working directory with a path
 var withWorkingDir = function(path) {
     if (workingDirectory === '.') return path;

--- a/packages/action/out/587.index.js
+++ b/packages/action/out/587.index.js
@@ -17,6 +17,7 @@ exports.modules = {
 /* harmony export */   "a2": () => (/* binding */ baseBranch),
 /* harmony export */   "cR": () => (/* binding */ owner),
 /* harmony export */   "dm": () => (/* binding */ versionFiles),
+/* harmony export */   "hJ": () => (/* binding */ prTitlePrefix),
 /* harmony export */   "hl": () => (/* binding */ commit_hash),
 /* harmony export */   "kD": () => (/* binding */ prereleaseType),
 /* harmony export */   "pE": () => (/* binding */ maxChangelogCommits),
@@ -43,6 +44,7 @@ var publishPackages = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('p
 var prereleaseType = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('prerelease-type') || 'canary';
 var baseBranch = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('base-branch') || 'main';
 var maxChangelogCommits = parseInt((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('max-changelog-commits') || '100', 10);
+var prTitlePrefix = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('pr-title-prefix') || '';
 // Helper to join working directory with a path
 var withWorkingDir = function(path) {
     if (workingDirectory === '.') return path;

--- a/packages/action/out/587.index.js
+++ b/packages/action/out/587.index.js
@@ -14,6 +14,7 @@ exports.modules = {
 /* harmony export */   "RL": () => (/* binding */ target_comment),
 /* harmony export */   "RP": () => (/* binding */ publishPackages),
 /* harmony export */   "Tf": () => (/* binding */ workingDirectory),
+/* harmony export */   "Zh": () => (/* binding */ prLabels),
 /* harmony export */   "a2": () => (/* binding */ baseBranch),
 /* harmony export */   "cR": () => (/* binding */ owner),
 /* harmony export */   "dm": () => (/* binding */ versionFiles),
@@ -45,6 +46,7 @@ var prereleaseType = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('pr
 var baseBranch = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('base-branch') || 'main';
 var maxChangelogCommits = parseInt((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('max-changelog-commits') || '100', 10);
 var prTitlePrefix = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('pr-title-prefix') || '';
+var prLabels = JSON.parse((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('pr-labels') || '[]');
 // Helper to join working directory with a path
 var withWorkingDir = function(path) {
     if (workingDirectory === '.') return path;

--- a/packages/action/out/587.index.js
+++ b/packages/action/out/587.index.js
@@ -13,6 +13,7 @@ exports.modules = {
 /* harmony export */   "QV": () => (/* binding */ withWorkingDir),
 /* harmony export */   "RL": () => (/* binding */ target_comment),
 /* harmony export */   "RP": () => (/* binding */ publishPackages),
+/* harmony export */   "Tf": () => (/* binding */ workingDirectory),
 /* harmony export */   "a2": () => (/* binding */ baseBranch),
 /* harmony export */   "cR": () => (/* binding */ owner),
 /* harmony export */   "dm": () => (/* binding */ versionFiles),
@@ -21,7 +22,7 @@ exports.modules = {
 /* harmony export */   "pE": () => (/* binding */ maxChangelogCommits),
 /* harmony export */   "sS": () => (/* binding */ initial_commit)
 /* harmony export */ });
-/* unused harmony exports target_pull, workingDirectory */
+/* unused harmony export target_pull */
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(1416);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _actions_github__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(7036);

--- a/packages/action/out/607.index.js
+++ b/packages/action/out/607.index.js
@@ -251,12 +251,10 @@ function _ts_generator(thisArg, body) {
 
 var runAction = function() {
     return _async_to_generator(function() {
-        var fullReleaseTitle, prereleaseTitle, stale, stalePrerelease, _iteratorAbruptCompletion, _didIteratorError, _iteratorError, _iterator, _step, _value, pulls, _iteratorNormalCompletion, _didIteratorError1, _iteratorError1, _iterator1, _step1, pull, err, _ref, prereleasePull, fullPull;
+        var stale, stalePrerelease, _iteratorAbruptCompletion, _didIteratorError, _iteratorError, _iterator, _step, _value, pulls, _iteratorNormalCompletion, _didIteratorError1, _iteratorError1, _iterator1, _step1, pull, err, _ref, prereleasePull, fullPull;
         return _ts_generator(this, function(_state) {
             switch(_state.label){
                 case 0:
-                    fullReleaseTitle = (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getFullReleaseTitle */ .n)();
-                    prereleaseTitle = (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getPrereleaseTitle */ .e)();
                     stale = [];
                     stalePrerelease = [];
                     _iteratorAbruptCompletion = false, _didIteratorError = false;
@@ -293,9 +291,13 @@ var runAction = function() {
                     try {
                         for(_iterator1 = pulls[Symbol.iterator](); !(_iteratorNormalCompletion = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion = true){
                             pull = _step1.value;
-                            if ((0,_util_is_action_user__WEBPACK_IMPORTED_MODULE_4__/* ["default"] */ .Z)(pull.user)) {
-                                if (fullReleaseTitle === pull.title) stale.push(pull);
-                                else if (prereleaseTitle === pull.title) stalePrerelease.push(pull);
+                            // Match by branch pattern instead of title (titles now include versions)
+                            if ((0,_util_is_action_user__WEBPACK_IMPORTED_MODULE_4__/* ["default"] */ .Z)(pull.user) && pull.head.ref.startsWith('turbo-module/release-')) {
+                                if (pull.head.ref.includes("-".concat(_context__WEBPACK_IMPORTED_MODULE_1__/* .prereleaseType */ .kD))) {
+                                    stalePrerelease.push(pull);
+                                } else {
+                                    stale.push(pull);
+                                }
                             }
                         }
                     } catch (err) {
@@ -468,11 +470,10 @@ var pull_labels = [
 ];
 var createPull = function(prerelease) {
     return _async_to_generator(function() {
-        var title, releaseLabel, primaryVersionFile, _ref, content, packageJson, newVersion, _ref1, _ref_data, sha, shortSha, branch, _iteratorNormalCompletion, _didIteratorError, _iteratorError, _iterator, _step, versionFile, filePath, _ref2, fileContent, filePackageJson, err, message, _ref3, pull, _$err, e;
+        var releaseLabel, primaryVersionFile, _ref, content, packageJson, newVersion, title, _ref1, _ref_data, sha, shortSha, branch, _iteratorNormalCompletion, _didIteratorError, _iteratorError, _iterator, _step, versionFile, filePath, _ref2, fileContent, filePackageJson, err, message, _ref3, pull, _$err, e;
         return _ts_generator(this, function(_state) {
             switch(_state.label){
                 case 0:
-                    title = prerelease ? (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getPrereleaseTitle */ .e)() : (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getFullReleaseTitle */ .n)();
                     releaseLabel = prerelease ? "releases: ".concat(_context__WEBPACK_IMPORTED_MODULE_1__/* .prereleaseType */ .kD) : 'releases: patch';
                     // Get the first version file to determine current version
                     primaryVersionFile = (0,_context__WEBPACK_IMPORTED_MODULE_1__/* .withWorkingDir */ .QV)(_context__WEBPACK_IMPORTED_MODULE_1__/* .versionFiles[0] */ .dm[0]);
@@ -494,6 +495,7 @@ var createPull = function(prerelease) {
                         newVersion = prerelease ? semver_functions_inc__WEBPACK_IMPORTED_MODULE_0___default()(packageJson.version, 'prerelease', _context__WEBPACK_IMPORTED_MODULE_1__/* .prereleaseType */ .kD) : semver_functions_inc__WEBPACK_IMPORTED_MODULE_0___default()(packageJson.version, 'patch');
                     }
                     if (!newVersion) throw new Error('Could not increase version');
+                    title = prerelease ? (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getPrereleaseTitle */ .e)(newVersion) : (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getFullReleaseTitle */ .n)(newVersion);
                     return [
                         4,
                         _context__WEBPACK_IMPORTED_MODULE_1__/* .octo.rest.git.getRef */ .NR.rest.git.getRef({
@@ -612,7 +614,8 @@ var createPull = function(prerelease) {
                             title: title,
                             body: message,
                             head: branch,
-                            base: _context__WEBPACK_IMPORTED_MODULE_1__/* .baseBranch */ .a2
+                            base: _context__WEBPACK_IMPORTED_MODULE_1__/* .baseBranch */ .a2,
+                            draft: true
                         })
                     ];
                 case 14:
@@ -690,11 +693,11 @@ var createPull = function(prerelease) {
 /* harmony export */ });
 /* harmony import */ var _context__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(7501);
 
-var getFullReleaseTitle = function() {
-    return '(turbo-module): release next version';
+var getFullReleaseTitle = function(version) {
+    return version ? "Release v".concat(version) : '(turbo-module): release next version';
 };
-var getPrereleaseTitle = function() {
-    return "(turbo-module): release next ".concat(_context__WEBPACK_IMPORTED_MODULE_0__/* .prereleaseType */ .kD, " version");
+var getPrereleaseTitle = function(version) {
+    return version ? "Release v".concat(version) : "(turbo-module): release next ".concat(_context__WEBPACK_IMPORTED_MODULE_0__/* .prereleaseType */ .kD, " version");
 };
 
 

--- a/packages/action/out/607.index.js
+++ b/packages/action/out/607.index.js
@@ -15,8 +15,8 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var semver_functions_inc__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(semver_functions_inc__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _context__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(7501);
 /* harmony import */ var _util_get_message__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(767);
-/* harmony import */ var _util_is_action_user__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(1514);
-/* harmony import */ var _shared__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(8089);
+/* harmony import */ var _util_is_action_user__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(1514);
+/* harmony import */ var _shared__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(8089);
 function _array_like_to_array(arr, len) {
     if (len == null || len > arr.length) len = arr.length;
     for(var i = 0, arr2 = new Array(len); i < len; i++)arr2[i] = arr[i];
@@ -251,12 +251,14 @@ function _ts_generator(thisArg, body) {
 
 var runAction = function() {
     return _async_to_generator(function() {
-        var stale, staleCanary, _iteratorAbruptCompletion, _didIteratorError, _iteratorError, _iterator, _step, _value, pulls, _iteratorNormalCompletion, _didIteratorError1, _iteratorError1, _iterator1, _step1, pull, err, _ref, canaryPull, fullPull;
+        var fullReleaseTitle, prereleaseTitle, stale, stalePrerelease, _iteratorAbruptCompletion, _didIteratorError, _iteratorError, _iterator, _step, _value, pulls, _iteratorNormalCompletion, _didIteratorError1, _iteratorError1, _iterator1, _step1, pull, err, _ref, prereleasePull, fullPull;
         return _ts_generator(this, function(_state) {
             switch(_state.label){
                 case 0:
+                    fullReleaseTitle = (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getFullReleaseTitle */ .n)();
+                    prereleaseTitle = (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getPrereleaseTitle */ .e)();
                     stale = [];
-                    staleCanary = [];
+                    stalePrerelease = [];
                     _iteratorAbruptCompletion = false, _didIteratorError = false;
                     _state.label = 1;
                 case 1:
@@ -291,9 +293,9 @@ var runAction = function() {
                     try {
                         for(_iterator1 = pulls[Symbol.iterator](); !(_iteratorNormalCompletion = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion = true){
                             pull = _step1.value;
-                            if ((0,_util_is_action_user__WEBPACK_IMPORTED_MODULE_3__/* ["default"] */ .Z)(pull.user)) {
-                                if (_shared__WEBPACK_IMPORTED_MODULE_4__/* .fullReleaseTitle */ .o === pull.title) stale.push(pull);
-                                else if (_shared__WEBPACK_IMPORTED_MODULE_4__/* .canaryReleaseTitle */ .G === pull.title) staleCanary.push(pull);
+                            if ((0,_util_is_action_user__WEBPACK_IMPORTED_MODULE_4__/* ["default"] */ .Z)(pull.user)) {
+                                if (fullReleaseTitle === pull.title) stale.push(pull);
+                                else if (prereleaseTitle === pull.title) stalePrerelease.push(pull);
                             }
                         }
                     } catch (err) {
@@ -368,7 +370,7 @@ var runAction = function() {
                     // close stale PRs and delete the branches
                     return [
                         4,
-                        Promise.all(_to_consumable_array(stale).concat(_to_consumable_array(staleCanary)).map(function(stalePull) {
+                        Promise.all(_to_consumable_array(stale).concat(_to_consumable_array(stalePrerelease)).map(function(stalePull) {
                             return _async_to_generator(function() {
                                 return _ts_generator(this, function(_state) {
                                     switch(_state.label){
@@ -415,13 +417,13 @@ var runAction = function() {
                     _ref = _sliced_to_array.apply(void 0, [
                         _state.sent(),
                         2
-                    ]), canaryPull = _ref[0], fullPull = _ref[1];
+                    ]), prereleasePull = _ref[0], fullPull = _ref[1];
                     // add comments to closed PRs that link to the newly created PRs
                     return [
                         4,
                         Promise.all([
-                            Promise.all(staleCanary.map(function(pull) {
-                                return addCommentToClosed(pull.number, canaryPull.number);
+                            Promise.all(stalePrerelease.map(function(pull) {
+                                return addCommentToClosed(pull.number, prereleasePull.number);
                             })),
                             Promise.all(stale.map(function(pull) {
                                 return addCommentToClosed(pull.number, fullPull.number);
@@ -466,18 +468,20 @@ var pull_labels = [
 ];
 var createPull = function(prerelease) {
     return _async_to_generator(function() {
-        var title, releaseLabel, _ref, content, packageJson, newVersion, _ref1, _ref_data, sha, shortSha, branch, message, _ref2, pull, err, e;
+        var title, releaseLabel, primaryVersionFile, _ref, content, packageJson, newVersion, _ref1, _ref_data, sha, shortSha, branch, _iteratorNormalCompletion, _didIteratorError, _iteratorError, _iterator, _step, versionFile, filePath, _ref2, fileContent, filePackageJson, err, message, _ref3, pull, _$err, e;
         return _ts_generator(this, function(_state) {
             switch(_state.label){
                 case 0:
-                    title = prerelease ? _shared__WEBPACK_IMPORTED_MODULE_4__/* .canaryReleaseTitle */ .G : _shared__WEBPACK_IMPORTED_MODULE_4__/* .fullReleaseTitle */ .o;
-                    releaseLabel = prerelease ? 'releases: canary' : 'releases: patch';
+                    title = prerelease ? (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getPrereleaseTitle */ .e)() : (0,_shared__WEBPACK_IMPORTED_MODULE_3__/* .getFullReleaseTitle */ .n)();
+                    releaseLabel = prerelease ? "releases: ".concat(_context__WEBPACK_IMPORTED_MODULE_1__/* .prereleaseType */ .kD) : 'releases: patch';
+                    // Get the first version file to determine current version
+                    primaryVersionFile = (0,_context__WEBPACK_IMPORTED_MODULE_1__/* .withWorkingDir */ .QV)(_context__WEBPACK_IMPORTED_MODULE_1__/* .versionFiles[0] */ .dm[0]);
                     return [
                         4,
                         _context__WEBPACK_IMPORTED_MODULE_1__/* .octo.rest.repos.getContent */ .NR.rest.repos.getContent({
                             repo: _context__WEBPACK_IMPORTED_MODULE_1__/* .repo */ .O9,
                             owner: _context__WEBPACK_IMPORTED_MODULE_1__/* .owner */ .cR,
-                            path: 'package.json'
+                            path: primaryVersionFile
                         })
                     ];
                 case 1:
@@ -485,24 +489,23 @@ var createPull = function(prerelease) {
                     if (!('content' in content)) throw new Error('Could not get package.json contents');
                     packageJson = JSON.parse(Buffer.from(content.content, 'base64').toString());
                     if (!packageJson.version || packageJson.version.startsWith('0.0.0')) {
-                        newVersion = prerelease ? '0.0.1-canary.0' : '0.0.1';
+                        newVersion = prerelease ? "0.0.1-".concat(_context__WEBPACK_IMPORTED_MODULE_1__/* .prereleaseType */ .kD, ".0") : '0.0.1';
                     } else {
-                        newVersion = prerelease ? semver_functions_inc__WEBPACK_IMPORTED_MODULE_0___default()(packageJson.version, 'prerelease', 'canary') : semver_functions_inc__WEBPACK_IMPORTED_MODULE_0___default()(packageJson.version, 'patch');
+                        newVersion = prerelease ? semver_functions_inc__WEBPACK_IMPORTED_MODULE_0___default()(packageJson.version, 'prerelease', _context__WEBPACK_IMPORTED_MODULE_1__/* .prereleaseType */ .kD) : semver_functions_inc__WEBPACK_IMPORTED_MODULE_0___default()(packageJson.version, 'patch');
                     }
                     if (!newVersion) throw new Error('Could not increase version');
-                    packageJson.version = newVersion;
                     return [
                         4,
                         _context__WEBPACK_IMPORTED_MODULE_1__/* .octo.rest.git.getRef */ .NR.rest.git.getRef({
                             owner: _context__WEBPACK_IMPORTED_MODULE_1__/* .owner */ .cR,
                             repo: _context__WEBPACK_IMPORTED_MODULE_1__/* .repo */ .O9,
-                            ref: "heads/main"
+                            ref: "heads/".concat(_context__WEBPACK_IMPORTED_MODULE_1__/* .baseBranch */ .a2)
                         })
                     ];
                 case 2:
                     _ref1 = _state.sent(), _ref_data = _ref1.data, sha = _ref_data.object.sha;
                     shortSha = sha.slice(0, 6) + sha.slice(-6);
-                    branch = prerelease ? "turbo-module/release-".concat(shortSha, "-canary") : "turbo-module/release-".concat(shortSha);
+                    branch = prerelease ? "turbo-module/release-".concat(shortSha, "-").concat(_context__WEBPACK_IMPORTED_MODULE_1__/* .prereleaseType */ .kD) : "turbo-module/release-".concat(shortSha);
                     return [
                         4,
                         _context__WEBPACK_IMPORTED_MODULE_1__/* .octo.rest.git.createRef */ .NR.rest.git.createRef({
@@ -514,25 +517,92 @@ var createPull = function(prerelease) {
                     ];
                 case 3:
                     _state.sent();
+                    _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
+                    _state.label = 4;
+                case 4:
+                    _state.trys.push([
+                        4,
+                        10,
+                        11,
+                        12
+                    ]);
+                    _iterator = _context__WEBPACK_IMPORTED_MODULE_1__/* .versionFiles */ .dm[Symbol.iterator]();
+                    _state.label = 5;
+                case 5:
+                    if (!!(_iteratorNormalCompletion = (_step = _iterator.next()).done)) return [
+                        3,
+                        9
+                    ];
+                    versionFile = _step.value;
+                    filePath = (0,_context__WEBPACK_IMPORTED_MODULE_1__/* .withWorkingDir */ .QV)(versionFile);
+                    console.log("Updating version in ".concat(filePath, " to ").concat(newVersion));
+                    return [
+                        4,
+                        _context__WEBPACK_IMPORTED_MODULE_1__/* .octo.rest.repos.getContent */ .NR.rest.repos.getContent({
+                            repo: _context__WEBPACK_IMPORTED_MODULE_1__/* .repo */ .O9,
+                            owner: _context__WEBPACK_IMPORTED_MODULE_1__/* .owner */ .cR,
+                            path: filePath,
+                            ref: branch
+                        })
+                    ];
+                case 6:
+                    _ref2 = _state.sent(), fileContent = _ref2.data;
+                    if (!('content' in fileContent)) throw new Error("Could not get ".concat(filePath, " contents"));
+                    filePackageJson = JSON.parse(Buffer.from(fileContent.content, 'base64').toString());
+                    filePackageJson.version = newVersion;
                     return [
                         4,
                         _context__WEBPACK_IMPORTED_MODULE_1__/* .octo.rest.repos.createOrUpdateFileContents */ .NR.rest.repos.createOrUpdateFileContents({
                             repo: _context__WEBPACK_IMPORTED_MODULE_1__/* .repo */ .O9,
                             owner: _context__WEBPACK_IMPORTED_MODULE_1__/* .owner */ .cR,
-                            path: 'package.json',
-                            message: "release patch ".concat(packageJson.version),
-                            content: Buffer.from(JSON.stringify(packageJson, null, 2) + '\n').toString('base64'),
-                            sha: content.sha,
+                            path: filePath,
+                            message: "release: ".concat(newVersion),
+                            content: Buffer.from(JSON.stringify(filePackageJson, null, 2) + '\n').toString('base64'),
+                            sha: fileContent.sha,
                             branch: branch
                         })
                     ];
-                case 4:
+                case 7:
                     _state.sent();
+                    _state.label = 8;
+                case 8:
+                    _iteratorNormalCompletion = true;
+                    return [
+                        3,
+                        5
+                    ];
+                case 9:
+                    return [
+                        3,
+                        12
+                    ];
+                case 10:
+                    err = _state.sent();
+                    _didIteratorError = true;
+                    _iteratorError = err;
+                    return [
+                        3,
+                        12
+                    ];
+                case 11:
+                    try {
+                        if (!_iteratorNormalCompletion && _iterator.return != null) {
+                            _iterator.return();
+                        }
+                    } finally{
+                        if (_didIteratorError) {
+                            throw _iteratorError;
+                        }
+                    }
+                    return [
+                        7
+                    ];
+                case 12:
                     return [
                         4,
                         (0,_util_get_message__WEBPACK_IMPORTED_MODULE_2__/* ["default"] */ .Z)(prerelease)
                     ];
-                case 5:
+                case 13:
                     message = _state.sent().message;
                     return [
                         4,
@@ -542,25 +612,25 @@ var createPull = function(prerelease) {
                             title: title,
                             body: message,
                             head: branch,
-                            base: 'main'
+                            base: _context__WEBPACK_IMPORTED_MODULE_1__/* .baseBranch */ .a2
                         })
                     ];
-                case 6:
-                    _ref2 = _state.sent(), pull = _ref2.data;
-                    err = 0;
-                    _state.label = 7;
-                case 7:
-                    if (!(err < 5)) return [
+                case 14:
+                    _ref3 = _state.sent(), pull = _ref3.data;
+                    _$err = 0;
+                    _state.label = 15;
+                case 15:
+                    if (!(_$err < 5)) return [
                         3,
-                        13
+                        21
                     ];
-                    _state.label = 8;
-                case 8:
+                    _state.label = 16;
+                case 16:
                     _state.trys.push([
-                        8,
-                        10,
+                        16,
+                        18,
                         ,
-                        12
+                        20
                     ]);
                     return [
                         4,
@@ -573,34 +643,34 @@ var createPull = function(prerelease) {
                             ])
                         })
                     ];
-                case 9:
+                case 17:
                     _state.sent();
                     return [
                         2,
                         pull
                     ];
-                case 10:
+                case 18:
                     e = _state.sent();
                     console.error(e);
-                    err++;
+                    _$err++;
                     return [
                         4,
                         new Promise(function(resolve) {
                             return setTimeout(resolve, 300);
                         })
                     ];
-                case 11:
+                case 19:
                     _state.sent();
                     return [
                         3,
-                        12
+                        20
                     ];
-                case 12:
+                case 20:
                     return [
                         3,
-                        7
+                        15
                     ];
-                case 13:
+                case 21:
                     throw new Error('Could not add labels to PR');
             }
         });
@@ -615,11 +685,17 @@ var createPull = function(prerelease) {
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   "G": () => (/* binding */ canaryReleaseTitle),
-/* harmony export */   "o": () => (/* binding */ fullReleaseTitle)
+/* harmony export */   "e": () => (/* binding */ getPrereleaseTitle),
+/* harmony export */   "n": () => (/* binding */ getFullReleaseTitle)
 /* harmony export */ });
-var fullReleaseTitle = '(turbo-module): release next version';
-var canaryReleaseTitle = '(turbo-module): release next canary version';
+/* harmony import */ var _context__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(7501);
+
+var getFullReleaseTitle = function() {
+    return '(turbo-module): release next version';
+};
+var getPrereleaseTitle = function() {
+    return "(turbo-module): release next ".concat(_context__WEBPACK_IMPORTED_MODULE_0__/* .prereleaseType */ .kD, " version");
+};
 
 
 /***/ })

--- a/packages/action/out/607.index.js
+++ b/packages/action/out/607.index.js
@@ -693,11 +693,17 @@ var createPull = function(prerelease) {
 /* harmony export */ });
 /* harmony import */ var _context__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(7501);
 
+var formatTitle = function(releaseType, version) {
+    var prefix = _context__WEBPACK_IMPORTED_MODULE_0__/* .prTitlePrefix */ .hJ ? "".concat(_context__WEBPACK_IMPORTED_MODULE_0__/* .prTitlePrefix */ .hJ, " ") : '';
+    var versionSuffix = version ? " v".concat(version) : '';
+    return "".concat(prefix).concat(releaseType).concat(versionSuffix).trim();
+};
 var getFullReleaseTitle = function(version) {
-    return version ? "Release v".concat(version) : '(turbo-module): release next version';
+    return formatTitle('Stable Release', version);
 };
 var getPrereleaseTitle = function(version) {
-    return version ? "Release v".concat(version) : "(turbo-module): release next ".concat(_context__WEBPACK_IMPORTED_MODULE_0__/* .prereleaseType */ .kD, " version");
+    var releaseType = _context__WEBPACK_IMPORTED_MODULE_0__/* .prereleaseType.charAt */ .kD.charAt(0).toUpperCase() + _context__WEBPACK_IMPORTED_MODULE_0__/* .prereleaseType.slice */ .kD.slice(1);
+    return formatTitle("".concat(releaseType, " Release"), version);
 };
 
 

--- a/packages/action/out/607.index.js
+++ b/packages/action/out/607.index.js
@@ -467,7 +467,7 @@ var addCommentToClosed = function(number, replacement) {
 var pull_labels = [
     'auto-release-pr',
     'keep up-to-date'
-];
+].concat(_to_consumable_array(_context__WEBPACK_IMPORTED_MODULE_1__/* .prLabels */ .Zh));
 var createPull = function(prerelease) {
     return _async_to_generator(function() {
         var releaseLabel, primaryVersionFile, _ref, content, packageJson, newVersion, title, _ref1, _ref_data, sha, shortSha, branch, _iteratorNormalCompletion, _didIteratorError, _iteratorError, _iterator, _step, versionFile, filePath, _ref2, fileContent, filePackageJson, err, message, _ref3, pull, _$err, e;

--- a/packages/action/out/767.index.js
+++ b/packages/action/out/767.index.js
@@ -13,6 +13,7 @@ exports.modules = {
 /* harmony export */   "QV": () => (/* binding */ withWorkingDir),
 /* harmony export */   "RL": () => (/* binding */ target_comment),
 /* harmony export */   "RP": () => (/* binding */ publishPackages),
+/* harmony export */   "Tf": () => (/* binding */ workingDirectory),
 /* harmony export */   "a2": () => (/* binding */ baseBranch),
 /* harmony export */   "cR": () => (/* binding */ owner),
 /* harmony export */   "dm": () => (/* binding */ versionFiles),
@@ -21,7 +22,7 @@ exports.modules = {
 /* harmony export */   "pE": () => (/* binding */ maxChangelogCommits),
 /* harmony export */   "sS": () => (/* binding */ initial_commit)
 /* harmony export */ });
-/* unused harmony exports target_pull, workingDirectory */
+/* unused harmony export target_pull */
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(1416);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _actions_github__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(7036);
@@ -245,6 +246,57 @@ var addPull = function(pulls, type, number, title) {
         title: title
     });
 };
+// Check if a commit touches files in the working directory
+var commitTouchesWorkingDir = function(sha) {
+    return _async_to_generator(function() {
+        var _commit_files, _ref, commit, _ref1, touchesDir, e;
+        return _ts_generator(this, function(_state) {
+            switch(_state.label){
+                case 0:
+                    if (context/* workingDirectory */.Tf === '.') return [
+                        2,
+                        true
+                    ]; // No filtering needed for root
+                    _state.label = 1;
+                case 1:
+                    _state.trys.push([
+                        1,
+                        3,
+                        ,
+                        4
+                    ]);
+                    return [
+                        4,
+                        context/* octo.rest.repos.getCommit */.NR.rest.repos.getCommit({
+                            owner: context/* owner */.cR,
+                            repo: context/* repo */.O9,
+                            ref: sha
+                        })
+                    ];
+                case 2:
+                    _ref = _state.sent(), commit = _ref.data;
+                    touchesDir = (_ref1 = (_commit_files = commit.files) === null || _commit_files === void 0 ? void 0 : _commit_files.some(function(file) {
+                        return file.filename.startsWith("".concat(context/* workingDirectory */.Tf, "/"));
+                    })) !== null && _ref1 !== void 0 ? _ref1 : false;
+                    return [
+                        2,
+                        touchesDir
+                    ];
+                case 3:
+                    e = _state.sent();
+                    // If we can't fetch the commit, include it to be safe
+                    return [
+                        2,
+                        true
+                    ];
+                case 4:
+                    return [
+                        2
+                    ];
+            }
+        });
+    })();
+};
 var collectCommits = function(head, base) {
     return _async_to_generator(function() {
         var stats, commitCount, _iteratorAbruptCompletion, _didIteratorError, _iteratorError, _iterator, _step, _value, commits, _iteratorNormalCompletion, _didIteratorError1, _iteratorError1, _iterator1, _step1, commit, _exec, _commit_author, message, PR, pull_number, _ref, pr, areas, _iteratorNormalCompletion1, _didIteratorError2, _iteratorError2, _iterator2, _step2, area, e, err, err1;
@@ -261,9 +313,9 @@ var collectCommits = function(head, base) {
                 case 1:
                     _state.trys.push([
                         1,
-                        15,
                         16,
-                        21
+                        17,
+                        22
                     ]);
                     _iterator = _async_iterator(context/* octo.paginate.iterator */.NR.paginate.iterator(context/* octo.rest.repos.compareCommits */.NR.rest.repos.compareCommits, {
                         owner: context/* owner */.cR,
@@ -281,7 +333,7 @@ var collectCommits = function(head, base) {
                 case 3:
                     if (!(_iteratorAbruptCompletion = !(_step = _state.sent()).done)) return [
                         3,
-                        14
+                        15
                     ];
                     _value = _step.value;
                     commits = _value.data.commits;
@@ -290,16 +342,16 @@ var collectCommits = function(head, base) {
                 case 4:
                     _state.trys.push([
                         4,
-                        11,
                         12,
-                        13
+                        13,
+                        14
                     ]);
                     _iterator1 = commits[Symbol.iterator]();
                     _state.label = 5;
                 case 5:
                     if (!!(_iteratorNormalCompletion = (_step1 = _iterator1.next()).done)) return [
                         3,
-                        10
+                        11
                     ];
                     commit = _step1.value;
                     if (context/* maxChangelogCommits */.pE > 0 && commitCount >= context/* maxChangelogCommits */.pE) {
@@ -310,31 +362,43 @@ var collectCommits = function(head, base) {
                         ];
                     }
                     commitCount++;
+                    return [
+                        4,
+                        commitTouchesWorkingDir(commit.sha)
+                    ];
+                case 6:
+                    // Skip commits that don't touch files in the working directory
+                    if (!_state.sent()) {
+                        return [
+                            3,
+                            10
+                        ];
+                    }
                     message = commit.commit.message.split('\n')[0];
                     PR = (_exec = /\(#(\d+)\)$/.exec(message)) === null || _exec === void 0 ? void 0 : _exec[1];
                     if (!PR) return [
                         3,
-                        9
+                        10
                     ];
                     pull_number = parseInt(PR);
                     if ((_commit_author = commit.author) === null || _commit_author === void 0 ? void 0 : _commit_author.login) {
                         if ((0,is_action_user/* default */.Z)(commit.author) && message.startsWith('release ')) return [
                             3,
-                            9
+                            10
                         ];
                         if (message.startsWith('(turbo-module): ')) return [
                             3,
-                            9
+                            10
                         ];
                         stats.authors.add(commit.author.login);
                     }
-                    _state.label = 6;
-                case 6:
+                    _state.label = 7;
+                case 7:
                     _state.trys.push([
-                        6,
-                        8,
+                        7,
+                        9,
                         ,
-                        9
+                        10
                     ]);
                     return [
                         4,
@@ -344,7 +408,7 @@ var collectCommits = function(head, base) {
                             pull_number: pull_number
                         })
                     ];
-                case 7:
+                case 8:
                     _ref = _state.sent(), pr = _ref.data;
                     areas = pr.labels.filter(function(param) {
                         var name = param.name;
@@ -377,37 +441,37 @@ var collectCommits = function(head, base) {
                     }
                     return [
                         3,
-                        9
+                        10
                     ];
-                case 8:
+                case 9:
                     e = _state.sent();
                     // PR might not exist in this repo (e.g., monorepo with commits from other repos)
                     console.log("Skipping PR #".concat(pull_number, " - not found in this repo"));
                     addPull(stats.pulls, 'general', pull_number, message);
                     return [
                         3,
-                        9
+                        10
                     ];
-                case 9:
+                case 10:
                     _iteratorNormalCompletion = true;
                     return [
                         3,
                         5
                     ];
-                case 10:
+                case 11:
                     return [
                         3,
-                        13
+                        14
                     ];
-                case 11:
+                case 12:
                     err = _state.sent();
                     _didIteratorError1 = true;
                     _iteratorError1 = err;
                     return [
                         3,
-                        13
+                        14
                     ];
-                case 12:
+                case 13:
                     try {
                         if (!_iteratorNormalCompletion && _iterator1.return != null) {
                             _iterator1.return();
@@ -420,60 +484,60 @@ var collectCommits = function(head, base) {
                     return [
                         7
                     ];
-                case 13:
+                case 14:
                     _iteratorAbruptCompletion = false;
                     return [
                         3,
                         2
                     ];
-                case 14:
+                case 15:
                     return [
                         3,
-                        21
+                        22
                     ];
-                case 15:
+                case 16:
                     err1 = _state.sent();
                     _didIteratorError = true;
                     _iteratorError = err1;
                     return [
                         3,
-                        21
+                        22
                     ];
-                case 16:
+                case 17:
                     _state.trys.push([
-                        16,
+                        17,
                         ,
-                        19,
-                        20
+                        20,
+                        21
                     ]);
                     if (!(_iteratorAbruptCompletion && _iterator.return != null)) return [
                         3,
-                        18
+                        19
                     ];
                     return [
                         4,
                         _iterator.return()
                     ];
-                case 17:
-                    _state.sent();
-                    _state.label = 18;
                 case 18:
+                    _state.sent();
+                    _state.label = 19;
+                case 19:
                     return [
                         3,
-                        20
+                        21
                     ];
-                case 19:
+                case 20:
                     if (_didIteratorError) {
                         throw _iteratorError;
                     }
                     return [
                         7
                     ];
-                case 20:
+                case 21:
                     return [
                         7
                     ];
-                case 21:
+                case 22:
                     return [
                         2,
                         stats

--- a/packages/action/out/767.index.js
+++ b/packages/action/out/767.index.js
@@ -1410,7 +1410,7 @@ var lengthBuffer = 1000;
 var makeGithubReleaseMessage = function(stats) {
     var message = "\n".concat(Object.entries(stats.pulls).map(function(param) {
         var _param = get_message_sliced_to_array(param, 2), key = _param[0], pulls = _param[1];
-        return "\n### ".concat(capitalise(key), " Changes\n\n").concat(pulls.map(function(param) {
+        return "\n### ".concat(capitalise(key), " Changes\n\n").concat(pulls.slice().reverse().map(function(param) {
             var title = param.title;
             return "- ".concat(title);
         }).join('\n'), "\n");

--- a/packages/action/out/767.index.js
+++ b/packages/action/out/767.index.js
@@ -245,7 +245,7 @@ var addPull = function(pulls, type, number, title) {
 };
 var collectCommits = function(head, base) {
     return _async_to_generator(function() {
-        var stats, _iteratorAbruptCompletion, _didIteratorError, _iteratorError, _iterator, _step, _value, commits, _iteratorNormalCompletion, _didIteratorError1, _iteratorError1, _iterator1, _step1, commit, _exec, _commit_author, message, PR, pull_number, _ref, pr, areas, _iteratorNormalCompletion1, _didIteratorError2, _iteratorError2, _iterator2, _step2, area, err, err1;
+        var stats, _iteratorAbruptCompletion, _didIteratorError, _iteratorError, _iterator, _step, _value, commits, _iteratorNormalCompletion, _didIteratorError1, _iteratorError1, _iterator1, _step1, commit, _exec, _commit_author, message, PR, pull_number, _ref, pr, areas, _iteratorNormalCompletion1, _didIteratorError2, _iteratorError2, _iterator2, _step2, area, e, err, err1;
         return _ts_generator(this, function(_state) {
             switch(_state.label){
                 case 0:
@@ -258,9 +258,9 @@ var collectCommits = function(head, base) {
                 case 1:
                     _state.trys.push([
                         1,
-                        13,
-                        14,
-                        19
+                        15,
+                        16,
+                        21
                     ]);
                     _iterator = _async_iterator(context/* octo.paginate.iterator */.NR.paginate.iterator(context/* octo.rest.repos.compareCommits */.NR.rest.repos.compareCommits, {
                         owner: context/* owner */.cR,
@@ -278,7 +278,7 @@ var collectCommits = function(head, base) {
                 case 3:
                     if (!(_iteratorAbruptCompletion = !(_step = _state.sent()).done)) return [
                         3,
-                        12
+                        14
                     ];
                     _value = _step.value;
                     commits = _value.data.commits;
@@ -287,36 +287,44 @@ var collectCommits = function(head, base) {
                 case 4:
                     _state.trys.push([
                         4,
-                        9,
-                        10,
-                        11
+                        11,
+                        12,
+                        13
                     ]);
                     _iterator1 = commits[Symbol.iterator]();
                     _state.label = 5;
                 case 5:
                     if (!!(_iteratorNormalCompletion = (_step1 = _iterator1.next()).done)) return [
                         3,
-                        8
+                        10
                     ];
                     commit = _step1.value;
                     message = commit.commit.message.split('\n')[0];
                     PR = (_exec = /\(#(\d+)\)$/.exec(message)) === null || _exec === void 0 ? void 0 : _exec[1];
                     if (!PR) return [
                         3,
-                        7
+                        9
                     ];
                     pull_number = parseInt(PR);
                     if ((_commit_author = commit.author) === null || _commit_author === void 0 ? void 0 : _commit_author.login) {
                         if ((0,is_action_user/* default */.Z)(commit.author) && message.startsWith('release ')) return [
                             3,
-                            7
+                            9
                         ];
                         if (message.startsWith('(turbo-module): ')) return [
                             3,
-                            7
+                            9
                         ];
                         stats.authors.add(commit.author.login);
                     }
+                    _state.label = 6;
+                case 6:
+                    _state.trys.push([
+                        6,
+                        8,
+                        ,
+                        9
+                    ]);
                     return [
                         4,
                         context/* octo.rest.pulls.get */.NR.rest.pulls.get({
@@ -325,7 +333,7 @@ var collectCommits = function(head, base) {
                             pull_number: pull_number
                         })
                     ];
-                case 6:
+                case 7:
                     _ref = _state.sent(), pr = _ref.data;
                     areas = pr.labels.filter(function(param) {
                         var name = param.name;
@@ -356,27 +364,39 @@ var collectCommits = function(head, base) {
                             }
                         }
                     }
-                    _state.label = 7;
-                case 7:
+                    return [
+                        3,
+                        9
+                    ];
+                case 8:
+                    e = _state.sent();
+                    // PR might not exist in this repo (e.g., monorepo with commits from other repos)
+                    console.log("Skipping PR #".concat(pull_number, " - not found in this repo"));
+                    addPull(stats.pulls, 'general', pull_number, message);
+                    return [
+                        3,
+                        9
+                    ];
+                case 9:
                     _iteratorNormalCompletion = true;
                     return [
                         3,
                         5
                     ];
-                case 8:
+                case 10:
                     return [
                         3,
-                        11
+                        13
                     ];
-                case 9:
+                case 11:
                     err = _state.sent();
                     _didIteratorError1 = true;
                     _iteratorError1 = err;
                     return [
                         3,
-                        11
+                        13
                     ];
-                case 10:
+                case 12:
                     try {
                         if (!_iteratorNormalCompletion && _iterator1.return != null) {
                             _iterator1.return();
@@ -389,60 +409,60 @@ var collectCommits = function(head, base) {
                     return [
                         7
                     ];
-                case 11:
+                case 13:
                     _iteratorAbruptCompletion = false;
                     return [
                         3,
                         2
                     ];
-                case 12:
+                case 14:
                     return [
                         3,
-                        19
+                        21
                     ];
-                case 13:
+                case 15:
                     err1 = _state.sent();
                     _didIteratorError = true;
                     _iteratorError = err1;
                     return [
                         3,
-                        19
+                        21
                     ];
-                case 14:
+                case 16:
                     _state.trys.push([
-                        14,
+                        16,
                         ,
-                        17,
-                        18
+                        19,
+                        20
                     ]);
                     if (!(_iteratorAbruptCompletion && _iterator.return != null)) return [
                         3,
-                        16
+                        18
                     ];
                     return [
                         4,
                         _iterator.return()
                     ];
-                case 15:
+                case 17:
                     _state.sent();
-                    _state.label = 16;
-                case 16:
+                    _state.label = 18;
+                case 18:
                     return [
                         3,
-                        18
+                        20
                     ];
-                case 17:
+                case 19:
                     if (_didIteratorError) {
                         throw _iteratorError;
                     }
                     return [
                         7
                     ];
-                case 18:
+                case 20:
                     return [
                         7
                     ];
-                case 19:
+                case 21:
                     return [
                         2,
                         stats

--- a/packages/action/out/767.index.js
+++ b/packages/action/out/767.index.js
@@ -17,6 +17,7 @@ exports.modules = {
 /* harmony export */   "a2": () => (/* binding */ baseBranch),
 /* harmony export */   "cR": () => (/* binding */ owner),
 /* harmony export */   "dm": () => (/* binding */ versionFiles),
+/* harmony export */   "hJ": () => (/* binding */ prTitlePrefix),
 /* harmony export */   "hl": () => (/* binding */ commit_hash),
 /* harmony export */   "kD": () => (/* binding */ prereleaseType),
 /* harmony export */   "pE": () => (/* binding */ maxChangelogCommits),
@@ -43,6 +44,7 @@ var publishPackages = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('p
 var prereleaseType = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('prerelease-type') || 'canary';
 var baseBranch = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('base-branch') || 'main';
 var maxChangelogCommits = parseInt((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('max-changelog-commits') || '100', 10);
+var prTitlePrefix = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('pr-title-prefix') || '';
 // Helper to join working directory with a path
 var withWorkingDir = function(path) {
     if (workingDirectory === '.') return path;

--- a/packages/action/out/767.index.js
+++ b/packages/action/out/767.index.js
@@ -14,6 +14,7 @@ exports.modules = {
 /* harmony export */   "RL": () => (/* binding */ target_comment),
 /* harmony export */   "RP": () => (/* binding */ publishPackages),
 /* harmony export */   "Tf": () => (/* binding */ workingDirectory),
+/* harmony export */   "Zh": () => (/* binding */ prLabels),
 /* harmony export */   "a2": () => (/* binding */ baseBranch),
 /* harmony export */   "cR": () => (/* binding */ owner),
 /* harmony export */   "dm": () => (/* binding */ versionFiles),
@@ -45,6 +46,7 @@ var prereleaseType = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('pr
 var baseBranch = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('base-branch') || 'main';
 var maxChangelogCommits = parseInt((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('max-changelog-commits') || '100', 10);
 var prTitlePrefix = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('pr-title-prefix') || '';
+var prLabels = JSON.parse((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('pr-labels') || '[]');
 // Helper to join working directory with a path
 var withWorkingDir = function(path) {
     if (workingDirectory === '.') return path;

--- a/packages/action/out/767.index.js
+++ b/packages/action/out/767.index.js
@@ -10,12 +10,17 @@ exports.modules = {
 /* harmony export */   "NR": () => (/* binding */ octo),
 /* harmony export */   "O9": () => (/* binding */ repo),
 /* harmony export */   "PX": () => (/* binding */ target_issue),
+/* harmony export */   "QV": () => (/* binding */ withWorkingDir),
 /* harmony export */   "RL": () => (/* binding */ target_comment),
+/* harmony export */   "RP": () => (/* binding */ publishPackages),
+/* harmony export */   "a2": () => (/* binding */ baseBranch),
 /* harmony export */   "cR": () => (/* binding */ owner),
+/* harmony export */   "dm": () => (/* binding */ versionFiles),
 /* harmony export */   "hl": () => (/* binding */ commit_hash),
+/* harmony export */   "kD": () => (/* binding */ prereleaseType),
 /* harmony export */   "sS": () => (/* binding */ initial_commit)
 /* harmony export */ });
-/* unused harmony export target_pull */
+/* unused harmony exports target_pull, workingDirectory */
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(1416);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _actions_github__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(7036);
@@ -29,6 +34,17 @@ var octo = (0,_actions_github__WEBPACK_IMPORTED_MODULE_1__.getOctokit)(GITHUB_TO
 var _context_repo = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.repo, _context_payload = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload;
 var owner = _context_repo.owner, repo = _context_repo.repo, commit_hash = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.sha, target_issue = _context_payload.issue, target_comment = _context_payload.comment, target_pull = _context_payload.pull_request;
 var initial_commit = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('initial-commit');
+// Monorepo support configuration
+var workingDirectory = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('working-directory') || '.';
+var versionFiles = JSON.parse((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('version-files') || '["package.json"]');
+var publishPackages = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('publish-packages') ? JSON.parse((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('publish-packages')) : undefined;
+var prereleaseType = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('prerelease-type') || 'canary';
+var baseBranch = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('base-branch') || 'main';
+// Helper to join working directory with a path
+var withWorkingDir = function(path) {
+    if (workingDirectory === '.') return path;
+    return "".concat(workingDirectory, "/").concat(path);
+};
 
 
 /***/ }),

--- a/packages/action/out/767.index.js
+++ b/packages/action/out/767.index.js
@@ -18,6 +18,7 @@ exports.modules = {
 /* harmony export */   "dm": () => (/* binding */ versionFiles),
 /* harmony export */   "hl": () => (/* binding */ commit_hash),
 /* harmony export */   "kD": () => (/* binding */ prereleaseType),
+/* harmony export */   "pE": () => (/* binding */ maxChangelogCommits),
 /* harmony export */   "sS": () => (/* binding */ initial_commit)
 /* harmony export */ });
 /* unused harmony exports target_pull, workingDirectory */
@@ -40,6 +41,7 @@ var versionFiles = JSON.parse((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getI
 var publishPackages = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('publish-packages') ? JSON.parse((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('publish-packages')) : undefined;
 var prereleaseType = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('prerelease-type') || 'canary';
 var baseBranch = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('base-branch') || 'main';
+var maxChangelogCommits = parseInt((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('max-changelog-commits') || '100', 10);
 // Helper to join working directory with a path
 var withWorkingDir = function(path) {
     if (workingDirectory === '.') return path;
@@ -245,7 +247,7 @@ var addPull = function(pulls, type, number, title) {
 };
 var collectCommits = function(head, base) {
     return _async_to_generator(function() {
-        var stats, _iteratorAbruptCompletion, _didIteratorError, _iteratorError, _iterator, _step, _value, commits, _iteratorNormalCompletion, _didIteratorError1, _iteratorError1, _iterator1, _step1, commit, _exec, _commit_author, message, PR, pull_number, _ref, pr, areas, _iteratorNormalCompletion1, _didIteratorError2, _iteratorError2, _iterator2, _step2, area, e, err, err1;
+        var stats, commitCount, _iteratorAbruptCompletion, _didIteratorError, _iteratorError, _iterator, _step, _value, commits, _iteratorNormalCompletion, _didIteratorError1, _iteratorError1, _iterator1, _step1, commit, _exec, _commit_author, message, PR, pull_number, _ref, pr, areas, _iteratorNormalCompletion1, _didIteratorError2, _iteratorError2, _iterator2, _step2, area, e, err, err1;
         return _ts_generator(this, function(_state) {
             switch(_state.label){
                 case 0:
@@ -253,6 +255,7 @@ var collectCommits = function(head, base) {
                         authors: new Set(),
                         pulls: {}
                     };
+                    commitCount = 0;
                     _iteratorAbruptCompletion = false, _didIteratorError = false;
                     _state.label = 1;
                 case 1:
@@ -299,6 +302,14 @@ var collectCommits = function(head, base) {
                         10
                     ];
                     commit = _step1.value;
+                    if (context/* maxChangelogCommits */.pE > 0 && commitCount >= context/* maxChangelogCommits */.pE) {
+                        console.log("Reached max commit limit (".concat(context/* maxChangelogCommits */.pE, "), stopping changelog scan"));
+                        return [
+                            2,
+                            stats
+                        ];
+                    }
+                    commitCount++;
                     message = commit.commit.message.split('\n')[0];
                     PR = (_exec = /\(#(\d+)\)$/.exec(message)) === null || _exec === void 0 ? void 0 : _exec[1];
                     if (!PR) return [

--- a/packages/action/out/967.index.js
+++ b/packages/action/out/967.index.js
@@ -390,10 +390,18 @@ var release = function() {
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "Z": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-var isCanary = function(test) {
-    return /^\d+\.\d+\.\d+-canary\.\d+$/.test(test);
+/* unused harmony export isPrerelease */
+/* harmony import */ var _context__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(7501);
+
+// Check if version matches the configured prerelease type (e.g., canary, beta)
+var isPrerelease = function(test) {
+    var pattern = new RegExp("^\\d+\\.\\d+\\.\\d+-".concat(_context__WEBPACK_IMPORTED_MODULE_0__/* .prereleaseType */ .kD, "\\.\\d+$"));
+    return pattern.test(test);
 };
+// Legacy export for backwards compatibility
+var isCanary = isPrerelease;
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (isCanary);
+
 
 
 /***/ })

--- a/packages/action/src/context.ts
+++ b/packages/action/src/context.ts
@@ -16,3 +16,20 @@ export const {
 } = context;
 
 export const initial_commit: string | undefined = getInput('initial-commit');
+
+// Monorepo support configuration
+export const workingDirectory: string = getInput('working-directory') || '.';
+export const versionFiles: string[] = JSON.parse(
+  getInput('version-files') || '["package.json"]',
+);
+export const publishPackages: string[] | undefined = getInput('publish-packages')
+  ? JSON.parse(getInput('publish-packages'))
+  : undefined;
+export const prereleaseType: string = getInput('prerelease-type') || 'canary';
+export const baseBranch: string = getInput('base-branch') || 'main';
+
+// Helper to join working directory with a path
+export const withWorkingDir = (path: string): string => {
+  if (workingDirectory === '.') return path;
+  return `${workingDirectory}/${path}`;
+};

--- a/packages/action/src/context.ts
+++ b/packages/action/src/context.ts
@@ -29,6 +29,7 @@ export const prereleaseType: string = getInput('prerelease-type') || 'canary';
 export const baseBranch: string = getInput('base-branch') || 'main';
 export const maxChangelogCommits: number = parseInt(getInput('max-changelog-commits') || '100', 10);
 export const prTitlePrefix: string = getInput('pr-title-prefix') || '';
+export const prLabels: string[] = JSON.parse(getInput('pr-labels') || '[]');
 
 // Helper to join working directory with a path
 export const withWorkingDir = (path: string): string => {

--- a/packages/action/src/context.ts
+++ b/packages/action/src/context.ts
@@ -27,6 +27,7 @@ export const publishPackages: string[] | undefined = getInput('publish-packages'
   : undefined;
 export const prereleaseType: string = getInput('prerelease-type') || 'canary';
 export const baseBranch: string = getInput('base-branch') || 'main';
+export const maxChangelogCommits: number = parseInt(getInput('max-changelog-commits') || '100', 10);
 
 // Helper to join working directory with a path
 export const withWorkingDir = (path: string): string => {

--- a/packages/action/src/context.ts
+++ b/packages/action/src/context.ts
@@ -28,6 +28,7 @@ export const publishPackages: string[] | undefined = getInput('publish-packages'
 export const prereleaseType: string = getInput('prerelease-type') || 'canary';
 export const baseBranch: string = getInput('base-branch') || 'main';
 export const maxChangelogCommits: number = parseInt(getInput('max-changelog-commits') || '100', 10);
+export const prTitlePrefix: string = getInput('pr-title-prefix') || '';
 
 // Helper to join working directory with a path
 export const withWorkingDir = (path: string): string => {

--- a/packages/action/src/release-pull/create.ts
+++ b/packages/action/src/release-pull/create.ts
@@ -7,6 +7,7 @@ import {
   prereleaseType,
   baseBranch,
   withWorkingDir,
+  prLabels,
 } from '../context';
 import getReleaseMessage from '../util/get-message';
 import isActionUser from '../util/is-action-user';
@@ -80,7 +81,7 @@ const addCommentToClosed = async (number: number, replacement: number) => {
   });
 };
 
-const pull_labels = ['auto-release-pr', 'keep up-to-date'];
+const pull_labels = ['auto-release-pr', 'keep up-to-date', ...prLabels];
 
 export const createPull = async (prerelease: boolean) => {
   const releaseLabel = prerelease

--- a/packages/action/src/release-pull/shared.ts
+++ b/packages/action/src/release-pull/shared.ts
@@ -1,8 +1,15 @@
-import { prereleaseType } from '../context';
+import { prereleaseType, prTitlePrefix } from '../context';
+
+const formatTitle = (releaseType: string, version?: string) => {
+  const prefix = prTitlePrefix ? `${prTitlePrefix} ` : '';
+  const versionSuffix = version ? ` v${version}` : '';
+  return `${prefix}${releaseType}${versionSuffix}`.trim();
+};
 
 export const getFullReleaseTitle = (version?: string) =>
-  version ? `Release v${version}` : '(turbo-module): release next version';
-export const getPrereleaseTitle = (version?: string) =>
-  version
-    ? `Release v${version}`
-    : `(turbo-module): release next ${prereleaseType} version`;
+  formatTitle('Stable Release', version);
+
+export const getPrereleaseTitle = (version?: string) => {
+  const releaseType = prereleaseType.charAt(0).toUpperCase() + prereleaseType.slice(1);
+  return formatTitle(`${releaseType} Release`, version);
+};

--- a/packages/action/src/release-pull/shared.ts
+++ b/packages/action/src/release-pull/shared.ts
@@ -1,2 +1,5 @@
-export const fullReleaseTitle = '(turbo-module): release next version';
-export const canaryReleaseTitle = '(turbo-module): release next canary version';
+import { prereleaseType } from '../context';
+
+export const getFullReleaseTitle = () => '(turbo-module): release next version';
+export const getPrereleaseTitle = () =>
+  `(turbo-module): release next ${prereleaseType} version`;

--- a/packages/action/src/release-pull/shared.ts
+++ b/packages/action/src/release-pull/shared.ts
@@ -1,5 +1,8 @@
 import { prereleaseType } from '../context';
 
-export const getFullReleaseTitle = () => '(turbo-module): release next version';
-export const getPrereleaseTitle = () =>
-  `(turbo-module): release next ${prereleaseType} version`;
+export const getFullReleaseTitle = (version?: string) =>
+  version ? `Release v${version}` : '(turbo-module): release next version';
+export const getPrereleaseTitle = (version?: string) =>
+  version
+    ? `Release v${version}`
+    : `(turbo-module): release next ${prereleaseType} version`;

--- a/packages/action/src/util/get-message.ts
+++ b/packages/action/src/util/get-message.ts
@@ -18,7 +18,11 @@ ${Object.entries(stats.pulls)
     ([key, pulls]) => `
 ### ${capitalise(key)} Changes
 
-${pulls.map(({ title }) => `- ${title}`).join('\n')}
+${pulls
+  .slice()
+  .reverse()
+  .map(({ title }) => `- ${title}`)
+  .join('\n')}
 `,
   )
   .join('')}

--- a/packages/action/src/util/is-canary.ts
+++ b/packages/action/src/util/is-canary.ts
@@ -1,3 +1,13 @@
-const isCanary = (test: string) => /^\d+\.\d+\.\d+-canary\.\d+$/.test(test);
+import { prereleaseType } from '../context';
+
+// Check if version matches the configured prerelease type (e.g., canary, beta)
+const isPrerelease = (test: string) => {
+  const pattern = new RegExp(`^\\d+\\.\\d+\\.\\d+-${prereleaseType}\\.\\d+$`);
+  return pattern.test(test);
+};
+
+// Legacy export for backwards compatibility
+const isCanary = isPrerelease;
 
 export default isCanary;
+export { isPrerelease };


### PR DESCRIPTION
## Summary

Adds support for using turbo-module in monorepo setups where:
- The package lives in a subdirectory (e.g., `developer-platform/`)
- Multiple package.json files need version updates in sync
- Custom prerelease types are needed (e.g., `beta` instead of `canary`)

### New Inputs

| Input | Description | Default |
|-------|-------------|---------|
| `working-directory` | Subdirectory to operate in | `.` |
| `version-files` | JSON array of package.json paths to update | `["package.json"]` |
| `publish-packages` | JSON array of packages to publish | scans `packages/*` |
| `prerelease-type` | Prerelease identifier (canary, beta, etc.) | `canary` |
| `base-branch` | Base branch for PRs | `main` |
| `max-changelog-commits` | Max commits to scan for changelog (0=unlimited) | `100` |

### Bug Fixes

- Handle non-existent PRs gracefully (commits from other repos in a monorepo)
- Add commit limit to prevent scanning thousands of commits
- Filter changelog to only include commits touching the working directory

### Backwards Compatible

Existing repos using turbo-module will continue to work with no changes - all new inputs have sensible defaults.

## Test Plan

- [x] Tested with `developer-platform-test-sdk-release.yml` workflow in whop-monorepo
- [x] Verified release PRs are created with correct version bumps in all 3 package.json files
- [x] Verified changelog only includes commits touching `developer-platform/`
- [x] Verified changelog generation completes quickly with commit limit